### PR TITLE
Remove security checks on name_get

### DIFF
--- a/base_extended_security/controllers/main.py
+++ b/base_extended_security/controllers/main.py
@@ -122,7 +122,6 @@ class DataSetWithExtendedSearchSecurity(DataSet):
 
 READ_WRITE_UNLINK_METHODS = [
     'read',
-    'name_get',
     'write',
     'unlink',
 ]
@@ -145,8 +144,7 @@ class DataSetWithExtendedSecurity(DataSetWithExtendedSearchSecurity):
     def _call_kw(self, model, method, args, kwargs):
         if method in READ_WRITE_UNLINK_METHODS:
             record_ids = args[0]
-            method_to_check = 'read' if method == 'name_get' else method
-            self._check_extended_security_rules(model, method_to_check, record_ids)
+            self._check_extended_security_rules(model, method, record_ids)
 
         result = super()._call_kw(model, method, args, kwargs)
 

--- a/base_extended_security/tests/test_controllers.py
+++ b/base_extended_security/tests/test_controllers.py
@@ -253,21 +253,6 @@ class TestControllers(SavepointCase):
     def test_on_read_with_customer__access_error_not_raised(self):
         self._read(self.customer | self.supplier_customer)
 
-    def _name_get(self, records):
-        with mock_odoo_request(self.env):
-            return self.controller.call('res.partner', 'name_get', [records.ids])
-
-    def test_on_name_get_with_employee__access_error_raised(self):
-        with pytest.raises(AccessError, match=EMPLOYEE_ACCESS_MESSAGE):
-            self._name_get(self.employee)
-
-    def test_on_name_get_with_non_customer__access_error_raised(self):
-        with pytest.raises(AccessError, match=NON_CUSTOMER_READ_MESSAGE):
-            self._name_get(self.supplier)
-
-    def test_on_name_get_with_customer__access_error_not_raised(self):
-        self._name_get(self.customer | self.supplier_customer)
-
     def _write(self, records, values):
         with mock_odoo_request(self.env):
             return self.controller.call('res.partner', 'write', [records.ids, values])


### PR DESCRIPTION
name_get is more complex to securize than other api methods.
The reason is that it is called when initializing a form view with default values.

For example, if a user clicks on 'Create' in an inventory adjustment form.
Suppose the default location is not authorized for this user.
The client calls name_get to get the name of the location.
An error is raised without letting the user change the location.
This situation is blocking.

Also, name_get is not much relevant for security.
Seeing the name of a record rarely is a security concern, because in most cases,
the name does not contain sensible information.

One exception is the name_get of employee addresses. However, for these records,
a rule is already defined at the orm level. Therefore, it does not need to be blocked at the rpc level.

https://isidor.numigi.net/web#id=12181&view_type=form&model=project.task&menu_id=200