### PR TITLE
TA#15755 Improve module private_data_group

### DIFF
--- a/base_extended_security/models/base.py
+++ b/base_extended_security/models/base.py
@@ -58,9 +58,3 @@ class BaseWithExtendedSecurity(models.AbstractModel):
         self.env['extended.security.rule'].check_user_access(
             model=self._name, access_type='unlink',
         )
-
-    def check_extended_security_name_get(self):
-        """Check extended security rules for name_get operations."""
-        self.env['extended.security.rule'].check_user_access(
-            model=self._name, access_type='name_get',
-        )

--- a/base_extended_security/models/extended_security_rule.py
+++ b/base_extended_security/models/extended_security_rule.py
@@ -24,7 +24,6 @@ class ExtendedSecurityRule(models.Model):
     perm_write = fields.Boolean('Write')
     perm_create = fields.Boolean('Create')
     perm_unlink = fields.Boolean('Delete')
-    perm_name_get = fields.Boolean('Name Get')
     active = fields.Boolean(default=True)
 
     @api.model_create_multi

--- a/base_extended_security/tests/test_crud.py
+++ b/base_extended_security/tests/test_crud.py
@@ -192,13 +192,6 @@ class TestControllers(ControllerCase):
         with pytest.raises(AccessError, match=NON_CUSTOMER_CREATE_MESSAGE):
             self._name_create('My Partner')
 
-    def _name_get(self, records):
-        with mock_odoo_request(self.env):
-            return self.controller.call('res.partner', 'name_get', [records.ids])
-
-    def test_on_name_get__access_error_not_raised(self):
-        self._name_get(self.employee)
-
     def _read_many2many_tags(self, records):
         with mock_odoo_request(self.env):
             fields = ['display_name', 'color']

--- a/private_data_group/security/res_groups.xml
+++ b/private_data_group/security/res_groups.xml
@@ -7,6 +7,7 @@
 
     <record id="group_private_data" model="res.groups">
         <field name="name">Manage Private Information</field>
+        <field name="users" eval="[(4, ref('base.user_root'))]"/>
     </record>
 
 </odoo>

--- a/private_data_group/tests/test_dataset_controllers.py
+++ b/private_data_group/tests/test_dataset_controllers.py
@@ -29,6 +29,7 @@ class TestControllers(TransactionCase):
         self.domain = [('id', '=', self.employee.id)]
 
         self.controller = DataSetWithPrivateFields()
+        self.env = self.env(user=self.user)
 
     def test_private_field_removed_from_read_request(self):
         with mock_odoo_request(self.env):

--- a/private_data_group/tests/test_res_partner.py
+++ b/private_data_group/tests/test_res_partner.py
@@ -37,17 +37,6 @@ class TestResPartner(common.SavepointCase):
         with pytest.raises(AccessError):
             self.private_address.sudo(self.user).check_extended_security_all()
 
-    def test_if_is_authorized__access_error_not_raised_on_name_get(self):
-        self.user.groups_id |= self.group
-        self.private_address.sudo(self.user).check_extended_security_name_get()
-
-    def test_if_partner_is_not_private__access_error_not_raised_on_name_get(self):
-        self.contact.sudo(self.user).check_extended_security_name_get()
-
-    def test_if_not_authorized__access_error_raised_on_name_get(self):
-        with pytest.raises(AccessError):
-            self.private_address.sudo(self.user).check_extended_security_name_get()
-
     def _search_partners(self):
         partner_pool = self.env['res.partner'].sudo(self.user)
         domain = partner_pool.get_extended_security_domain()

--- a/private_data_group/tests/test_web_export.py
+++ b/private_data_group/tests/test_web_export.py
@@ -21,6 +21,8 @@ class TestWebExport(TransactionCase):
         })
         self.controller = CSVControllerWithPrivateFields()
 
+        self.env = self.env(user=self.env.ref("base.user_demo"))
+
     def _export(self, ids, domain, fields, model='hr.employee'):
         params = {
             'model': model,


### PR DESCRIPTION
Add more flexibility over the control of access of private addresses.
A new method check_private_address_access is available.
This method can be inherited to implemented to add specific rules
over private addresses.

Also remove dead code from the module base_extended_security.