### PR TITLE
TA#30212 simplify access api

### DIFF
--- a/base_extended_security/controllers/crud.py
+++ b/base_extended_security/controllers/crud.py
@@ -171,25 +171,21 @@ class _ExtendedSecurityVerifier:
 def _check_read_rules(model, record_ids):
     records = _browse_records(model, record_ids)
     records.check_extended_security_read()
-    records.check_extended_security_all()
 
 
 def _check_write_rules(model, record_ids):
     records = _browse_records(model, record_ids)
     records.check_extended_security_write()
-    records.check_extended_security_all()
 
 
 def _check_create_rules(model, record_ids):
     records = _browse_records(model, record_ids)
     records.check_extended_security_create()
-    records.check_extended_security_all()
 
 
 def _check_unlink_rules(model, record_ids):
     records = _browse_records(model, record_ids)
     records.check_extended_security_unlink()
-    records.check_extended_security_all()
 
 
 def _browse_records(model, record_ids):

--- a/base_extended_security/controllers/web_export.py
+++ b/base_extended_security/controllers/web_export.py
@@ -16,7 +16,6 @@ class ExportFormatWithSecurityDomain(ExportFormat):
 
         if record_ids:
             records = request.env[model].browse(record_ids)
-            records.check_extended_security_all()
             records.check_extended_security_read()
         else:
             search_domain = params.get('domain') or []

--- a/base_extended_security/models/base.py
+++ b/base_extended_security/models/base.py
@@ -23,16 +23,7 @@ class BaseWithExtendedSecurity(models.AbstractModel):
         )
 
     def check_extended_security_all(self):
-        """Check extended security rules that applies for all CRUD operations.
-
-        This method excludes the name_get operation.
-
-        The reason is that name_get is much less likely to be a security
-        issue for most use cases.
-
-        Blocking name_get also causes errors in the web.interface,
-        because of Many2one fields.
-        """
+        """Check extended security rules that applies for all CRUD operations."""
         pass
 
     def check_extended_security_read(self):
@@ -40,21 +31,25 @@ class BaseWithExtendedSecurity(models.AbstractModel):
         self.env['extended.security.rule'].check_user_access(
             model=self._name, access_type='read',
         )
+        self.check_extended_security_all()
 
     def check_extended_security_write(self):
         """Check extended security rules for write operations."""
         self.env['extended.security.rule'].check_user_access(
             model=self._name, access_type='write',
         )
+        self.check_extended_security_all()
 
     def check_extended_security_create(self):
         """Check extended security rules for create operations."""
         self.env['extended.security.rule'].check_user_access(
             model=self._name, access_type='create',
         )
+        self.check_extended_security_all()
 
     def check_extended_security_unlink(self):
         """Check extended security rules for unlink operations."""
         self.env['extended.security.rule'].check_user_access(
             model=self._name, access_type='unlink',
         )
+        self.check_extended_security_all()


### PR DESCRIPTION
When checking read/write/create/delete access, only one
method should be called instead of calling two methods.

check_extended_security_all should always be called when checking access.