### PR TITLE
TA#41437 Microsoft SSO: Use sub if email not given

### DIFF
--- a/auth_oauth_microsoft/models/res_users.py
+++ b/auth_oauth_microsoft/models/res_users.py
@@ -27,7 +27,7 @@ class Users(models.Model):
 
         provider_obj = self.env["auth.oauth.provider"].browse(provider)
         if _is_microsoft_endpoint(provider_obj.auth_endpoint):
-            validation["user_id"] = validation["email"]
+            validation["user_id"] = validation.get("email") or validation["sub"]
 
         return validation
 


### PR DESCRIPTION
When a user logs in with a personnal accounts, the email field is not given when accessing the user-info endpoint.